### PR TITLE
Remove stray Chart.js reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     
     <!-- CSS -->
     <link rel="stylesheet" href="css/styles.css">


### PR DESCRIPTION
## Summary
- delete unused Chart.js CDN script from index.html

## Testing
- `npx -y htmlhint index.html`
- `npx -y eslint js/*.js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6889ac12ad7c8320ae9144bcbbd7c89f